### PR TITLE
fix(v3widgets):fix v3 widgets sync [ ORB-2943 ]

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Magento 2.1+ (Module version 2.7.5 up to 2.7.7)
 
 Magento 2.2+ (Module version 2.8.0 and above)
 
+Magento 2.4.8 (Module version 4.3.2 and above)
+
 ## ✓ Install via [composer](https://getcomposer.org/download/) (recommended)
 Run the following command under your Magento 2 root dir:
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-reviews",
     "description": "Yotpo Reviews extension for Magento2",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -9,7 +9,7 @@
     "require": {
         "php": "~5.6.0|^7.0|^8.0",
         "magento/framework": ">=102.0.0",
-        "yotpo/module-yotpo-core": "4.3.1"
+        "yotpo/module-yotpo-core": "4.3.2"
     },
     "type": "magento2-module",
     "autoload": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Reviews" setup_version="4.3.1">
+    <module name="Yotpo_Reviews" setup_version="4.3.2">
         <sequence>
             <Yotpo_Core/>
         </sequence>


### PR DESCRIPTION
Explicitly pass `$storeId` around, because otherwise the different functions rely on a default store and not on the currently selected one.