### PR TITLE
Bump core version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-reviews",
     "description": "Yotpo Reviews extension for Magento2",
-    "version": "4.3.4",
+    "version": "4.3.5",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -9,7 +9,7 @@
     "require": {
         "php": "~5.6.0|^7.0|^8.0",
         "magento/framework": ">=102.0.0",
-        "yotpo/module-yotpo-core": "4.3.4"
+        "yotpo/module-yotpo-core": "4.3.5"
     },
     "type": "magento2-module",
     "autoload": {


### PR DESCRIPTION
Yotpo Core module has introduced PHP 8.4 compatiblity changes back last year, however the reviews module requirements are still requesting older version preventing latest module installation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to `composer.json` version/dependency constraints, with no runtime code modifications; risk is primarily compatibility if `yotpo-core` 4.3.5 has breaking changes.
> 
> **Overview**
> Updates the module release and dependency constraints by bumping `yotpo/module-yotpo-reviews` to `4.3.5` and requiring `yotpo/module-yotpo-core` `4.3.5` (from `4.3.4`) to allow installation with the newer core module.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 212b73550319e27d6c34444337010c35553ef565. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->