### PR TITLE
feat(core):bump version to get compatible with Magento 2.4.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-reviews",
     "description": "Yotpo Reviews extension for Magento2",
-    "version": "4.3.6",
+    "version": "4.3.7",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -9,7 +9,7 @@
     "require": {
         "php": "~5.6.0|^7.0|^8.0",
         "magento/framework": ">=102.0.0",
-        "yotpo/module-yotpo-core": "4.3.6"
+        "yotpo/module-yotpo-core": "4.3.7"
     },
     "type": "magento2-module",
     "autoload": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Reviews" setup_version="4.3.2">
+    <module name="Yotpo_Reviews" setup_version="4.3.7">
         <sequence>
             <Yotpo_Core/>
         </sequence>


### PR DESCRIPTION
### Jira Link
https://yotpoent.atlassian.net/browse/TS-15

### Summary
Bumping version in order to make yotpo on-site widget compatible with Magento 2.4.9